### PR TITLE
misc: match declaration and definition signatures

### DIFF
--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -1595,7 +1595,7 @@ lwip_netconn_do_send(void *m)
 #endif /* LWIP_UDP */
 #if LWIP_NETPACKET
         case NETCONN_NETPACKET_RAW:
-          if (msg->msg.b->netpacket_hwaddr != NULL && msg->msg.b->netpacket_hwaddr_len != 0) {
+          if (msg->msg.b->netpacket_hwaddr_len != 0) {
             err = LWIP_HOOK_NETPACKET_SENDTO(msg->conn->pcb.netpacket, msg->msg.b->p,
                                              msg->msg.b->netpacket_hwaddr, msg->msg.b->netpacket_hwaddr_len);
           } else {

--- a/src/netif/ppp/chap_ms.c
+++ b/src/netif/ppp/chap_ms.c
@@ -152,7 +152,7 @@ extern void set_mppe_enc_types(int, int);
 
 static void	ascii2unicode (const char[], int, u_char[]);
 static void	NTPasswordHash (u_char *, int, u_char[MD4_SIGNATURE_SIZE]);
-static void	ChallengeResponse (const u_char *, const u_char *, u_char[24]);
+static void	ChallengeResponse (const u_char *, const u_char[MD4_SIGNATURE_SIZE], u_char[24]);
 static void	ChallengeHash (const u_char[16], const u_char *, const char *, u_char[8]);
 static void	ChapMS_NT (const u_char *, const char *, int, u_char[24]);
 static void	ChapMS2_NT (const u_char *, const u_char[16], const char *, const char *, int,
@@ -872,7 +872,7 @@ static void ChapMS(ppp_pcb *pcb, const u_char *rchallenge, const char *secret, i
  */
 static void ChapMS2(ppp_pcb *pcb, const u_char *rchallenge, const u_char *PeerChallenge,
 	const char *user, const char *secret, int secret_len, unsigned char *response,
-	u_char authResponse[], int authenticator) {
+	u_char authResponse[MS_AUTH_RESPONSE_LENGTH+1], int authenticator) {
     /* ARGSUSED */
     LWIP_UNUSED_ARG(authenticator);
 #if !MPPE_SUPPORT


### PR DESCRIPTION
JIRA: RTOS-927

Warnings fixed:
```
 /github/workspace/phoenix-rtos-lwip/lib-lwip/src/api/api_msg.c: In function 'lwip_netconn_do_send':
Warning: /github/workspace/phoenix-rtos-lwip/lib-lwip/src/api/api_msg.c:1598:44: warning: the comparison will always evaluate as 'true' for the address of 'netpacket_hwaddr' will never be NULL [-Waddress]
 1598 |           if (msg->msg.b->netpacket_hwaddr != NULL && msg->msg.b->netpacket_hwaddr_len != 0) {
      |                                            ^~
In file included from lib-lwip/src/include/lwip/api.h:47,
                 from lib-lwip/src/include/lwip/priv/api_msg.h:47,
                 from /github/workspace/phoenix-rtos-lwip/lib-lwip/src/api/api_msg.c:43:
lib-lwip/src/include/lwip/netbuf.h:73:8: note: 'netpacket_hwaddr' declared here
   73 |   u8_t netpacket_hwaddr[ETH_HWADDR_LEN];
      |        ^~~~~~~~~~~~~~~~
 ```
 ```
  Warning: /github/workspace/phoenix-rtos-lwip/lib-lwip/src/netif/ppp/chap_ms.c:497:32: warning: argument 2 of type 'const u_char[16]' {aka 'const unsigned char[16]'} with mismatched bound [-Warray-parameter=]
 497 |                   const u_char PasswordHash[MD4_SIGNATURE_SIZE],
     |                   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/github/workspace/phoenix-rtos-lwip/lib-lwip/src/netif/ppp/chap_ms.c:155:52: note: previously declared as 'const u_char *' {aka 'const unsigned char *'}
 155 | static void     ChallengeResponse (const u_char *, const u_char *, u_char[24]);
     |                                                    ^~~~~~~~~~~~~~
Warning: /github/workspace/phoenix-rtos-lwip/lib-lwip/src/netif/ppp/chap_ms.c:875:16: warning: argument 8 of type 'u_char[]' {aka 'unsigned char[]'} with mismatched bound [-Warray-parameter=]
 875 |         u_char authResponse[], int authenticator) {
     |         ~~~~~~~^~~~~~~~~~~~~~
/github/workspace/phoenix-rtos-lwip/lib-lwip/src/netif/ppp/chap_ms.c:179:29: note: previously declared as 'u_char[41]' {aka 'unsigned char[41]'}
 179 |                   u_char *, u_char[MS_AUTH_RESPONSE_LENGTH+1], int);
 ```